### PR TITLE
StaticArrays support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,8 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 julia = "1.7"
 
 [extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["StaticArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1.7"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Packages to calculate the Smith and Hermite normal forms already exist, but this
 several advantages. First, it integrates into pre-existing infrastructure provided by the
 `LinearAlgebra` standard library by exporting the `RowHermite`, `ColumnHermite`, and `Smith` types,
 which are subtypes of `LinearAlgebra.Factorization`. Second, effort has been made to thoroughly
-comment the code so the algorithms can be easily understood.
+comment the code so the algorithms can be easily understood. Third, the code is integrated with
+StaticArrays.jl, and methods are available for `SMatrix`, which cannot be mutated in-place.
 
 This package only works with Julia 1.7 and above due to the use of `LinearAlgebra.det_bareiss` to
 calculate exact integer determinants.
@@ -23,7 +24,6 @@ calculate exact integer determinants.
 This package is not complete by any means, and the following outstanding issues exist:
   * Smith normal forms are not yet available.
   * Documentation and testing are far from complete.
-  * No integration with `StaticArrays` exists yet.
 
 # See also
 

--- a/src/NormalForms.jl
+++ b/src/NormalForms.jl
@@ -1,6 +1,7 @@
 module NormalForms
 
 using LinearAlgebra
+using Requires
 import Base.setindex
 
 # Efficient algorithm for calculating determinants of integer matrices
@@ -30,5 +31,12 @@ export NegativeOffDiagonal, PositiveOffDiagonal
 export hnfc!, hnfc, hnfr!, hnfr
 include("smith.jl")
 export Smith
+
+function __init__()
+    # Contains methods specific to SMatrix, which can't be mutated in-place
+    @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" begin
+        include("staticarrays.jl")
+    end
+end
 
 end

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,7 +1,7 @@
 using .StaticArrays
 
 # TODO: perhaps extend this for the sake of StaticArrays?
-detb(M::SMatrix) = LinearAlgebra.det_bareiss!(convert(Matrix, M))
+detb(M::SMatrix) = LinearAlgebra.det_bareiss!(convert(MMatrix, M))
 
 function hnfc(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
     (H, U, info) = hnf_ma!(MMatrix(M), R)

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,0 +1,14 @@
+using .StaticArrays
+
+# TODO: perhaps extend this for the sake of StaticArrays?
+detb(M::SMatrix) = LinearAlgebra.det_bareiss!(convert(Matrix, M))
+
+function hnfc(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
+    (H, U, info) = hnf_ma!(MMatrix(M), R)
+    return ColumnHermite(SMatrix{D1,D2}(H), SMatrix{D1,D2}(U), info)
+end
+
+function hnfr(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
+    (H, U, info) = hnf_ma!(MMatrix(M'), R)
+    return RowHermite(SMatrix{D1,D2}(H'), SMatrix{D1,D2}(U'), info)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-using NormalForms
 using Test
+using NormalForms
+using StaticArrays
 
 @testset "NormalForms.jl" begin
     # Write your tests here.
@@ -9,6 +10,14 @@ using Test
         Fc = hnfc(M)
         @test M * Fc.U == Fc.H
         @test Fr.U * M == Fr.H
+    end
+    @testset "SMatrix" begin
+        S = SMatrix{3,3,Int}([-2 1 1; 2 -1 1; 2 1 -1])
+        Fr = hnfr(S)
+        Fc = hnfc(S)
+        @test isbits(Fr)
+        @test S * Fc.U == Fc.H
+        @test Fr.U * S == Fr.H
     end
 end
 


### PR DESCRIPTION
This required a new definition of `det_bareiss()` for `SMatrix`, which honestly might be good PR material for the [StaticArrays](https://github.com/JuliaArrays/StaticArrays.jl) repo. Otherwise, everything seems to work fine.