### PR TITLE
Make the Bareiss determinant algorithm available to allow Julia 1.6 compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -4,8 +4,14 @@ Copyright (c) 2022 Brandon Flores
 
 Some of this package's code originates from the HermiteNormalForms.jl package,
 authored by Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod. This code 
-is distributed under the same license. The repository can be found at:
+is also available under the MIT license. The repository can be found at:
 https://github.com/YingboMa/HermiteNormalForm.jl
+
+The Bareiss determinant algorithm was pulled from the Julia 1.8 source code
+for compatibility with Julia versions prior to 1.7. Julia 1.8 is also available
+under the MIT license.
+
+==
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 Requires = "1"
-julia = "1.7"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/NormalForms.jl
+++ b/src/NormalForms.jl
@@ -2,7 +2,6 @@ module NormalForms
 
 using LinearAlgebra
 using Requires
-import LinearAlgebra: det_bareiss as detb
 import Base: promote_typeof, swaprows!, swapcols!
 
 include("algorithms.jl")

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,7 +1,8 @@
 using .StaticArrays
 
+# Matrix appears slightly faster, but MMatrix allocates less memory
 # TODO: perhaps extend this for the sake of StaticArrays?
-detb(M::SMatrix) = LinearAlgebra.det_bareiss!(convert(MMatrix, M))
+detb(M::SMatrix) = detb!(convert(MMatrix, M))
 
 function hnfc(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
     (H, U, info) = hnf_ma!(MMatrix(M), R)


### PR DESCRIPTION
I'd like this package to work on the latest LTS, and `LinearAlgebra.det_bareiss()` is only available in Julia 1.7 and up. I've added the code from Julia's LinearAlgebra standard library to this code, so it should now work under 1.6.