### PR TITLE
Fix return types for `SMatrix` arguments

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -251,7 +251,6 @@ function enforce_divisibility!(A::AbstractMatrix, U::AbstractMatrix, V::Abstract
         swapcols!(A, k-1, k)
         swapcols!(V, k-1, k)
         # Use the Bezout coefficients to make A[k-1,k-1] == d
-        @info "test"
         for i in axes(A,2)
             A[k-1,i] += q * A[k,i]
             V[i,k-1] += p * V[i,k]

--- a/src/hermite.jl
+++ b/src/hermite.jl
@@ -38,7 +38,7 @@ struct RowHermite{T,M} <: AbstractHermite{T,M}
             join(size(H), '×'), " for H and ", join(size(U), '×'), "for U"
         )
         M = promote_typeof(H,U)
-        return new{eltype(M),M}(promote(H, U)..., info)
+        return new{eltype(M),M}(H, U, info)
     end
 end
 
@@ -65,7 +65,7 @@ struct ColumnHermite{T,M} <: AbstractHermite{T,M}
             join(size(H), '×'), " for H and ", join(size(U), '×'), "for U"
         )
         M = promote_typeof(H, U)
-        return new{eltype(M),M}(promote(H, U)..., info)
+        return new{eltype(M),M}(H, U, info)
     end
 end
 

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -6,12 +6,20 @@ detb(M::SMatrix) = detb!(convert(MMatrix, M))
 
 function hnfc(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
     (H, U, info) = hnf_ma!(MMatrix(M), R)
-    return ColumnHermite(SMatrix{D1,D2}(H), SMatrix{D1,D2}(U), info)
+    return ColumnHermite(SMatrix{D1,D2}(H), SMatrix{D2,D2}(U), info)
 end
 
 function hnfr(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
     (H, U, info) = hnf_ma!(MMatrix(M'), R)
-    return RowHermite(SMatrix{D1,D2}(H'), SMatrix{D1,D2}(U'), info)
+    return RowHermite(SMatrix{D1,D2}(H'), SMatrix{D1,D1}(U'), info)
 end
 
-snf(M::SMatrix{D1,D2,<:Integer}) where {D1,D2} = Smith(snf_ma!(MMatrix(M))...)
+function snf(M::SMatrix{D1,D2,<:Integer}) where {D1,D2}
+    result = snf_ma!(MMatrix(M))
+    return Smith(
+        SMatrix{D1,D2}(result[1]),
+        SMatrix{D1,D1}(result[2]),
+        SMatrix{D2,D2}(result[3]),
+        result[4]
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,5 +88,7 @@ end
   2  2  9  7 -5  3
  -2  6  3 -9 -3  5] (hnfc fails - also in HermiteNormalForm.jl)
 
- Anything with [1 1; 0 1] seems to break snf()
+[ -3  -2  -4   0
+ -2   3   2  -2
+ -1   2   2  -2 ] (unimodularity failure)
 =#


### PR DESCRIPTION
Currently, the return type for `snf(::SMatrix)` is a mess. This should fix that and ensure all fields of the `Smith` factorization are instances of `SMatrix`.

In the future, it would be nice to have a return type for `snf(::SMatrix)` and related functions that are pure bits. The current issue is that the unimodular matrices have different dimensions, so each field is not necessarily the same type: 
```julia-repl
julia> test = rand(-9:9, 4, 3) |> SMatrix{4,3}
4×3 SMatrix{4, 3, Int64, 12} with indices SOneTo(4)×SOneTo(3):
  4   1   3
  4   2  -6
  6  -3  -5
 -3   9  -8

julia> snf(test)
4×3 Smith{Int64, SArray{S, Int64, 2} where S<:Tuple}:
Smith normal form:
4×3 SMatrix{4, 3, Int64, 12} with indices SOneTo(4)×SOneTo(3):
 1  0  0
 0  1  0
 0  0  2
 0  0  0
Left unimodular factor:
4×4 SMatrix{4, 4, Int64, 16} with indices SOneTo(4)×SOneTo(4):
    1    0     0     0
 -104   76    19     1
   -9   33   -23   -14
  -66  237  -164  -100
Right unimodular factor:
3×3 SMatrix{3, 3, Int64, 9} with indices SOneTo(3)×SOneTo(3):
 0  -1  -871
 1   4  3481
 0   0     1
```