### PR TITLE
Fix Bezout coefficent ordering issue that causes Smith normal form calculations to get stuck

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -10,7 +10,8 @@ eye(T::Type, sz) = Matrix{T}(LinearAlgebra.I(sz))
 
 Generates an identity matrix of the same dimension as dimension `dim` of `M`.
 """
-eye(M::AbstractMatrix, dim) = typeof(M)(LinearAlgebra.I(size(M, dim)))
+eye(M::AbstractMatrix, dim) = typeof(M)(collect(UniformScaling(one(eltype(M)))(size(M, dim))))
+# Collect is needed for Julia 1.6 because Adjoint(::Diagonal) is undefined
 
 """
     NormalForms.detb!(M::AbstractMatrix)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -14,10 +14,12 @@ eye(M::AbstractMatrix, dim) = typeof(M)(collect(UniformScaling(one(eltype(M)))(s
 # Collect is needed for Julia 1.6 because Adjoint(::Diagonal) is undefined
 
 """
-    NormalForms.detb!(M::AbstractMatrix)
+    NormalForms.detb!(M::AbstractMatrix{T<:Number}) -> T
 
 Calculates the determinant of a matrix using the [Bareiss 
-algorithm](https://en.wikipedia.org/wiki/Bareiss_algorithm) using in-place operations.
+algorithm](https://en.wikipedia.org/wiki/Bareiss_algorithm) using in-place operations. This
+algorithm returns exact integer determinants for integer matrices, which is useful when checking
+whether a matrix is unimodular.
 
 This is a verbatim reimplementation of `LinearAlgebra.det_bareiss()` used to ensure compatibility
 with Julia 1.6, which does not have this function.

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,16 +1,16 @@
 """
     NormalForms.eye(T::Type, sz)
 
-Generates an identity matrix of size `sz`.
+Generates an identity matrix of size `sz` with elements of type `T`.
 """
 eye(T::Type, sz) = Matrix{T}(LinearAlgebra.I(sz))
 
 """
-    NormalForms.eye(M::AbstractMatrix{T}, dim)
+    NormalForms.eye(M::AbstractMatrix, dim)
 
-Generates an identity matrix of the same size as dimension `dim` of `M`.
+Generates an identity matrix of the same dimension as dimension `dim` of `M`.
 """
-eye(M::AbstractMatrix{T}, dim) where T = eye(T, size(M, dim))
+eye(M::AbstractMatrix, dim) = typeof(M)(LinearAlgebra.I(size(M, dim)))
 
 """
     NormalForms.detb!(M::AbstractMatrix)
@@ -134,11 +134,8 @@ are tracked in the matrix `U`, which will only undergo unimodular transforms.
     # This can safely be skipped if k is the last element
     k < last(axes(A,2)) && for j in axes(A,2)[k+1:end]
         # Take the GCD with the Kannen-Bachem modificaion
-        @info "j = $j"
         (d, p, q) = gcd_kb(A[ki, k], A[ki, j])
-        p < q && @warn "Warning: p < q"
         Akkd, Akjd = div(A[ki, k], d), div(A[ki, j], d)
-        @info "\nd = $d, p = $p, q = $q\nAkkd = $Akkd, Akjd = $Akjd"
         for i in axes(A,1)
             # Make copies for later reference (otherwise the algorithm breaks)
             Aik, Aij = A[i,k], A[i,j]
@@ -182,10 +179,8 @@ are tracked in the matrix `U`, which will only undergo unimodular transforms.
 )
     # This can safely be skipped if k is the last element
     k < last(axes(A,1)) && for j in axes(A,1)[k+1:end]
-        @info "j = $j"
         (d, p, q) = gcd_kb(A[k, ki], A[j, ki])
         Akkd, Ajkd = div(A[k, ki], d), div(A[j, ki], d)
-        @info "\nd = $d, p = $p, q = $q\nAkkd = $Akkd, Ajkd = $Ajkd"
         for i in axes(A,2)
             Aki, Aji = A[k,i], A[j,i]
             A[k,i] =  Aki * p + Aji * q
@@ -203,8 +198,7 @@ are tracked in the matrix `U`, which will only undergo unimodular transforms.
         Uk, Uj = U[k,:], U[j,:]
         @views U[k,:] =  Uk * p + Uj * q
         @views U[j,:] = -Uk * Ajkd + Uj * Akkd
-        (It was also faster than using a matrix multiplication)
-        @assert isunimodular(U) =#
+        (It was also faster than using a matrix multiplication) =#
     end
 end
 

--- a/src/hermite.jl
+++ b/src/hermite.jl
@@ -120,12 +120,6 @@ function hnf_ma!(
 )
     # Create the unimodular matrix as an identity matrix
     U = eye(A,2)
-    # Convert to a transpose 
-    if A isa Adjoint
-        U = U'
-    elseif A isa Transpose
-        U = transpose(U)
-    end
     # Loop through each row of A
     @inbounds for k in axes(A,1)
         pivot = find_pivot(A,k)

--- a/src/smith.jl
+++ b/src/smith.jl
@@ -75,14 +75,6 @@ function snf_ma!(A::AbstractMatrix{<:Integer})
     # Create the left and right unimodular matrices
     U = eye(A,1)
     V = eye(A,2)
-    # Convert to a transpose or adjoint if needed
-    if A isa Adjoint
-        U = U'
-        V = V'
-    elseif A isa Transpose
-        U = transpose(U)
-        V = transpose(V)
-    end
     # Loop through the smallest dimension of A
     for k in minimum(axes(A))
         pivot = find_pivot(A,k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,15 +4,19 @@ using NormalForms
 using LinearAlgebra
 using StaticArrays
 
+import NormalForms: eye, gcd_kb
+
 Aqua.test_all(NormalForms; project_toml_formatting=false)
 
 @testset "NormalForms.jl" verbose=true begin
     @testset "Algorithms" begin
         # If this fails, Smith normal form calculation may not terminate:
         # The critical part is that for the return value (r,p,q), abs(p) > abs(q)
-        @test NormalForms.gcd_kb(2,2) === (2,1,0)
+        @test gcd_kb(2,2) === (2,1,0)
         @test isunimodular(Float64[1 1; 0 1]) === true
         @test isunimodular([1/2 0; 0 2]) == false
+        @test eye(transpose(zeros(Bool, 3,4)), 2) == transpose(collect(LinearAlgebra.I(3)))
+        @test eye(adjoint(zeros(Bool, 3,4)), 2) == adjoint(collect(LinearAlgebra.I(3)))
     end
     @testset "Factorization assertions" begin
         # Diagonal checks for Smith normal form

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,9 @@ Aqua.test_all(NormalForms; project_toml_formatting=false)
 
 @testset "NormalForms.jl" verbose=true begin
     @testset "Algorithms" begin
-        # If this fails, Smith normal form calculation may not terminate
-        @test NormalForms.gcd_kb(1,1) === (1,1,0)
+        # If this fails, Smith normal form calculation may not terminate:
+        # The critical part is that for the return value (r,p,q), abs(p) > abs(q)
+        @test NormalForms.gcd_kb(2,2) === (2,1,0)
         @test isunimodular(Float64[1 1; 0 1]) === true
         @test isunimodular([1/2 0; 0 2]) == false
     end
@@ -86,9 +87,5 @@ end
 [ 9  7 -7  7 -3  7
  -1  5  0  7 -4 -1
   2  2  9  7 -5  3
- -2  6  3 -9 -3  5] (hnfc fails - also in HermiteNormalForm.jl)
-
-[ -3  -2  -4   0
- -2   3   2  -2
- -1   2   2  -2 ] (unimodularity failure)
+ -2  6  3 -9 -3  5] (unimodularity failure in hnfc - also in HermiteNormalForm.jl)
 =#


### PR DESCRIPTION
This completely fixes #4: the previous fix I put together didn't actually solve the issue for matrices which had rows or columns with identical numbers.

The root cause is that Julia's `gcdx(a,a)` returns the Bezout coefficients `(0, 1)`, but this ordering breaks the loop in `snf_ma!()` that zeros off-diagonal elements. The function `NormalForms.gcd_kb()` ensures that for identical arguments, the ordering is `(1,0)`.