### PR TITLE
Fix some `StaticMatrix` interoperability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Changed
+  - For non-square `StaticMatrix{D1,D2,T}` inputs, the return types of the factors are `Matrix{T}`.
+
+## Fixed
+  - Methods allowing interoperability with `StaticMatrix` types were too narrow to support arbitrary
+    immutable subtypes of `StaticMatrix`.
+
 ## [0.1.8] - 2024-03-27
 
 ## Fixed

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -2,19 +2,19 @@ using .StaticArrays
 
 # Matrix appears slightly faster, but MMatrix allocates less memory
 # TODO: perhaps extend this for the sake of StaticArrays?
-detb(M::SMatrix) = detb!(convert(MMatrix, M))
+detb(M::StaticMatrix) = detb!(convert(MMatrix, M))
 
-function hnfc(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
+function hnfc(M::StaticMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
     (H, U, info) = hnf_ma!(MMatrix(M), R)
     return ColumnHermite(SMatrix{D1,D2}(H), SMatrix{D2,D2}(U), info)
 end
 
-function hnfr(M::SMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
+function hnfr(M::StaticMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
     (H, U, info) = hnf_ma!(MMatrix(M'), R)
     return RowHermite(SMatrix{D1,D2}(H'), SMatrix{D1,D1}(U'), info)
 end
 
-function snf(M::SMatrix{D1,D2,<:Integer}) where {D1,D2}
+function snf(M::StaticMatrix{D1,D2,<:Integer}) where {D1,D2}
     result = snf_ma!(MMatrix(M))
     return Smith(
         SMatrix{D1,D2}(result[1]),

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -29,7 +29,7 @@ end
 
 function hnfr(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D,<:Integer}}
     (H, U, info) = hnf_ma!(MMatrix(M'), R)
-    return ColumnHermite(T(H'), T(U'), info)
+    return RowHermite(T(H'), T(U'), info)
 end
 
 function snf(M::T) where {D,T<:StaticMatrix{D,D,<:Integer}}

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -22,28 +22,22 @@ detb(M::StaticMatrix) = detb!(convert(MMatrix, M))
 =#
 
 # Square matrix methods
-function hnfc(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D,<:Integer}}
+function hnfc(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D}}
     (H, U, info) = hnf_ma!(MMatrix(M), R)
     return ColumnHermite(T(H), T(U), info)
 end
 
-function hnfr(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D,<:Integer}}
+function hnfr(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D}}
     (H, U, info) = hnf_ma!(MMatrix(M'), R)
     return RowHermite(T(H'), T(U'), info)
 end
 
-function snf(M::T) where {D,T<:StaticMatrix{D,D,<:Integer}}
+function snf(M::T) where {D,T<:StaticMatrix{D,D}}
     (S, U, V, info) = snf_ma!(MMatrix(M))
     return Smith(T(S), T(U), T(V), info)
 end
 
 # Non-square matrix methods
-function hnfc(M::StaticMatrix{<:Any,<:Any,<:Integer}, R::RoundingMode = NegativeOffDiagonal)
-    return hnfc!(collect(M), R)
-end
-
-function hnfr(M::StaticMatrix{<:Any,<:Any,<:Integer}, R::RoundingMode = NegativeOffDiagonal)
-    return hnfr!(collect(M), R)
-end
-
-snf(M::StaticMatrix{<:Any,<:Any,<:Integer}) = snf!(collect(M))
+hnfc(M::StaticMatrix, R::RoundingMode = NegativeOffDiagonal) = hnfc!(collect(M), R)
+hnfr(M::StaticMatrix, R::RoundingMode = NegativeOffDiagonal) = hnfr!(collect(M), R)
+snf(M::StaticMatrix) = snf!(collect(M))

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -4,22 +4,46 @@ using .StaticArrays
 # TODO: perhaps extend this for the sake of StaticArrays?
 detb(M::StaticMatrix) = detb!(convert(MMatrix, M))
 
-function hnfc(M::StaticMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
+#= TODO:
+    The RowHermite, ColumnHermite, and Smith types assume that the types of the normal form matrix 
+    and the types of the U/V factors are identical.
+
+    This is fine for Julia's Matrix type, but it is a serious problem for any StaticMatrix types
+    that do not represent square matrices: the U/V factors are going to be square matrices of
+    different sizes.
+
+    The stopgap solution is to return `Matrix` types for factorizations of non-square matrices.
+
+    In the future, there are two possible solutions to this issue:
+      * Increase the number of type parameters for the factorization types so everything can be
+        represented individually.
+      * Create specific factorization types for interoperability with StaticArrays.
+    I'm inclined to go with the latter (-BF)
+=#
+
+# Square matrix methods
+function hnfc(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D,<:Integer}}
     (H, U, info) = hnf_ma!(MMatrix(M), R)
-    return ColumnHermite(SMatrix{D1,D2}(H), SMatrix{D2,D2}(U), info)
+    return ColumnHermite(T(H), T(U), info)
 end
 
-function hnfr(M::StaticMatrix{D1,D2,<:Integer}, R::RoundingMode = NegativeOffDiagonal) where {D1,D2}
+function hnfr(M::T, R::RoundingMode = NegativeOffDiagonal) where {D,T<:StaticMatrix{D,D,<:Integer}}
     (H, U, info) = hnf_ma!(MMatrix(M'), R)
-    return RowHermite(SMatrix{D1,D2}(H'), SMatrix{D1,D1}(U'), info)
+    return ColumnHermite(T(H'), T(U'), info)
 end
 
-function snf(M::StaticMatrix{D1,D2,<:Integer}) where {D1,D2}
-    result = snf_ma!(MMatrix(M))
-    return Smith(
-        SMatrix{D1,D2}(result[1]),
-        SMatrix{D1,D1}(result[2]),
-        SMatrix{D2,D2}(result[3]),
-        result[4]
-    )
+function snf(M::T) where {D,T<:StaticMatrix{D,D,<:Integer}}
+    (S, U, V, info) = snf_ma!(MMatrix(M))
+    return Smith(T(S), T(U), T(V), info)
 end
+
+# Non-square matrix methods
+function hnfc(M::StaticMatrix{<:Any,<:Any,<:Integer}, R::RoundingMode = NegativeOffDiagonal)
+    return hnfc!(collect(M), R)
+end
+
+function hnfr(M::StaticMatrix{<:Any,<:Any,<:Integer}, R::RoundingMode = NegativeOffDiagonal)
+    return hnfr!(collect(M), R)
+end
+
+snf(M::StaticMatrix{<:Any,<:Any,<:Integer}) = snf!(collect(M))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,12 +64,24 @@ Aqua.test_all(NormalForms)
         @test Fr.U * M == Fr.H
         @test S.U * M * S.V == S.S
     end
-    @testset "SMatrix" begin
+    @testset "Square SMatrix" begin
         M = SMatrix{3,3,Int}([-2 1 1; 2 -1 1; 2 1 -1])
         Fr = hnfr(M)
         Fc = hnfc(M)
         S = snf(M)
         @test isbits(Fr)
+        @test M * Fc.U == Fc.H
+        @test Fr.U * M == Fr.H
+        @test S.U * M * S.V == S.S
+    end
+    @testset "Non-square SMatrix" begin
+        M = SMatrix{2,3,Int}([1 -2 3; -4 5 -6])
+        Fr = hnfr(M)
+        Fc = hnfc(M)
+        S = snf(M)
+        @test hnfr!(collect(M)) == Fr
+        @test hnfc!(collect(M)) == Fc
+        @test snf!(collect(M)) == S
         @test M * Fc.U == Fc.H
         @test Fr.U * M == Fr.H
         @test S.U * M * S.V == S.S


### PR DESCRIPTION
This PR fixes two problems:
1. In order to allow for interoperability with `SMatrix`, I defined specialized methods for `hnfc`, `hnfr`, and `snf`. However, the method signatures were too narrow to allow for interoperability with general immutable subtypes of `StaticMatrix`: they only worked on `SMatrix`. Now, any `StaticMatrix` subtype is converted to an `MMatrix` before the internal methods are called.
2. For non-square `StaticMatrix` argument inputs, the types of the `U`/`V` factors cannot match the argument type or the type of the normal form matrix, since they must be square matrices of differing dimensions. This cannot be specified with the current factorization types, so as a stopgap measure, the return types of the matrices are just `Matrix` with matching element type.