### PR TITLE
Provide internal implementations of `swaprows!` and `swapcols!`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,9 +7,9 @@ authored by Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod. This code
 is also available under the MIT license. The repository can be found at:
 https://github.com/YingboMa/HermiteNormalForm.jl
 
-The Bareiss determinant algorithm was pulled from the Julia 1.8 source code
-for compatibility with Julia versions prior to 1.7. Julia 1.8 is also available
-under the MIT license.
+Some algorithms, such as the Bareiss determinant algorithm and the
+reimplementation of row and column swapping for matrices, were based on Julia 
+source code. All Julia versions are also available under an MIT license.
 
 ==
 

--- a/src/NormalForms.jl
+++ b/src/NormalForms.jl
@@ -2,7 +2,7 @@ module NormalForms
 
 using LinearAlgebra
 using Requires
-import Base: promote_typeof, swaprows!, swapcols!
+import Base: promote_typeof
 
 include("algorithms.jl")
 export isunimodular

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,3 +1,4 @@
+#---Generate an identity matrix--------------------------------------------------------------------#
 """
     NormalForms.eye(T::Type, sz)
 
@@ -14,6 +15,7 @@ eye(M::AbstractMatrix, dim) = typeof(M)(collect(UniformScaling(one(eltype(M)))(s
 eye(M::Diagonal, dim = 1) = Diagonal(ones(eltype(M), size(M,dim)))
 # Collect is needed for Julia 1.6 because Adjoint(::Diagonal) is undefined
 
+#---Bareiss integer determinant algorithm (not present in Julia 1.6)-------------------------------#
 """
     NormalForms.detb!(M::AbstractMatrix{T<:Number}) -> T
 
@@ -54,6 +56,7 @@ Algorithm](https://en.wikipedia.org/wiki/Bareiss_algorithm) without modifying `M
 """
 detb(M::AbstractMatrix) = detb!(copy(M))
 
+#---Unimodularity checks---------------------------------------------------------------------------#
 """
     isunimodular(M::AbstractMatrix)
 
@@ -72,6 +75,7 @@ end
 
 # TODO: a unimodular inverse?
 
+#---Kannen-Bachem modification to GCD algorithm----------------------------------------------------#
 """
     NormalForms.gcd_kb(x::Integer, y::Integer) -> NTuple{3,promote_typeof(x,y)}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,11 @@ Aqua.test_all(NormalForms)
         @test eye(transpose(zeros(Bool, 3,4)), 2) == transpose(collect(LinearAlgebra.I(3)))
         @test eye(adjoint(zeros(Bool, 3,4)), 2) == adjoint(collect(LinearAlgebra.I(3)))
         @test eye(Diagonal([1,2,3]), 2) == Diagonal([1,1,1])
+        A = [1 2 3; 4 5 6]
+        @test NormalForms.swapcols!(A, 1, 2) == [2 1 3; 5 4 6]
+        @test NormalForms.swapcols!(A, 1, 2) == [1 2 3; 4 5 6]
+        @test NormalForms.swaprows!(A, 1, 2) == [4 5 6; 1 2 3]
+        @test NormalForms.swaprows!(A, 1, 2) == [1 2 3; 4 5 6]
     end
     @testset "Factorization assertions" begin
         # Diagonal checks for Smith normal form


### PR DESCRIPTION
We shouldn't depend on the Base implementations because they are not exported.